### PR TITLE
display docs list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 build-storybook.log
 storybook-static
 
+# Draft
+*.draft*

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -16,7 +16,7 @@ const getCollection = async (key: string) => {
   }
 
   if (key === 'docs') {
-    const response = await strapiClient.getPosts({ page: 1, pageSize: 30 }, { filter: '', sort: '' });
+    const response = await strapiClient.getPosts({ page: 1, pageSize: 30 }, { filter: '', sort: 'updatedAt:desc' });
     collection = response?.data as Store[] || [];
   }
 

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { strapiClient } from '@/markket/api';
 import { Store } from "@/markket/store.d";
 
 import StoreGrid from '@/app/components/stores/grid';
+import DocsGrid from '@/app/components/docs/grid';
 
 const defaultLogo = `https://markketplace.nyc3.digitaloceanspaces.com/uploads/1a82697eaeeb5b376d6983f452d1bf3d.png`;
 
@@ -14,7 +15,12 @@ const getCollection = async (key: string) => {
     collection = response?.data as Store[] || [];
   }
 
-  console.log({ collection })
+  if (key === 'docs') {
+    const response = await strapiClient.getPosts({ page: 1, pageSize: 30 }, { filter: '', sort: '' });
+    collection = response?.data as Store[] || [];
+  }
+
+  console.log({ collection: collection.length, key });
 
   return {
     data: collection || [],
@@ -62,6 +68,15 @@ export default async function AnyPage({ params }: { params: Promise<{ slug: stri
 
         {page_slug === 'stores' && (
           <StoreGrid stores={collection.data} />
+        )}
+
+        {page_slug === 'docs' && (
+          <>
+            <Title order={2} className="text-center mb-8">
+              Documentation & Articles
+            </Title>
+            <DocsGrid posts={collection.data} />
+          </>
         )}
 
       </Stack>

--- a/app/components/docs/card.tsx
+++ b/app/components/docs/card.tsx
@@ -50,8 +50,8 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
       </Text>
 
       <Group gap="xs">
-        {post.Tags?.map((tag) => (
-          <Badge key={tag.name} variant="light">
+        {post.Tags?.map((tag, index) => (
+          <Badge key={index} variant="light">
             <IconTag size={14} className="mr-1" />
             {tag.name}
           </Badge>

--- a/app/components/docs/card.tsx
+++ b/app/components/docs/card.tsx
@@ -1,0 +1,62 @@
+import { Card, Image, Text, Badge, Group } from '@mantine/core';
+import { IconCalendar, IconTag } from '@tabler/icons-react';
+
+interface BlogPostCardProps {
+  post: {
+    Title: string;
+    Content: string;
+    publishedAt: string;
+    SEO: {
+      metaDescription: string;
+    };
+    Tags: Array<{ name: string }>;
+    cover: {
+      data: {
+        attributes: {
+          url: string;
+        };
+      };
+    };
+  };
+}
+
+export function BlogPostCard({ post }: BlogPostCardProps) {
+  return (
+    <Card shadow="sm" padding="lg" radius="md" withBorder>
+      {post?.cover?.data?.attributes?.url && (
+        <Card.Section>
+          <Image
+            src={post.cover.data.attributes.url}
+            height={200}
+            alt={post?.Title}
+          />
+        </Card.Section>
+      )}
+
+      <Group justify="space-between" mt="md" mb="xs">
+        <Text fw={500} size="lg" lineClamp={2}>
+          {post?.Title}
+        </Text>
+        <Group gap="xs">
+          <IconCalendar size={14} />
+          <Text size="sm" c="dimmed">
+            {new Date(post.publishedAt).toLocaleDateString()}
+          </Text>
+        </Group>
+      </Group>
+
+      <Text size="sm" c="dimmed" mb="md" lineClamp={3}>
+        {post?.SEO?.metaDescription}
+      </Text>
+
+      <Group gap="xs">
+        {post.Tags?.map((tag) => (
+          <Badge key={tag.name} variant="light">
+            <IconTag size={14} className="mr-1" />
+            {tag.name}
+          </Badge>
+        ))}
+      </Group>
+    </Card>
+  );
+};

--- a/app/components/docs/grid.tsx
+++ b/app/components/docs/grid.tsx
@@ -1,11 +1,11 @@
 import { SimpleGrid } from '@mantine/core';
 import { BlogPostCard } from './card';
 
-interface BlogGridProps {
+interface DocsGridProps {
   posts: any[];
 }
 
-export function BlogGrid({ posts }: BlogGridProps) {
+export function DocsGrid({ posts }: DocsGridProps) {
   return (
     <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
       {posts.map((post) => (
@@ -15,4 +15,4 @@ export function BlogGrid({ posts }: BlogGridProps) {
   );
 };
 
-export default BlogGrid;
+export default DocsGrid;

--- a/app/components/docs/grid.tsx
+++ b/app/components/docs/grid.tsx
@@ -1,0 +1,18 @@
+import { SimpleGrid } from '@mantine/core';
+import { BlogPostCard } from './card';
+
+interface BlogGridProps {
+  posts: any[];
+}
+
+export function BlogGrid({ posts }: BlogGridProps) {
+  return (
+    <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+      {posts.map((post) => (
+        <BlogPostCard key={post.id} post={post} />
+      ))}
+    </SimpleGrid>
+  );
+};
+
+export default BlogGrid;

--- a/app/components/docs/grid.tsx
+++ b/app/components/docs/grid.tsx
@@ -8,8 +8,8 @@ interface DocsGridProps {
 export function DocsGrid({ posts }: DocsGridProps) {
   return (
     <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
-      {posts.map((post) => (
-        <BlogPostCard key={post.id} post={post} />
+      {posts.map((post, index) => (
+        <BlogPostCard key={index} post={post} />
       ))}
     </SimpleGrid>
   );

--- a/markket/api.ts
+++ b/markket/api.ts
@@ -65,11 +65,19 @@ export class StrapiClient {
     });
   }
 
-  async getPosts() {
+  async getPosts(paginate: { page: number; pageSize: number }, options: { filter: string, sort: string }) {
+    const { filter, sort } = options;
+
     return this.fetch({
-      contentType: 'article',
-      filters: { store: { slug: { $eq: this.storeSlug } } },
-      populate: 'SEO.socialImage,Tags,store,cover'
+      contentType: 'articles',
+      sort,
+      filters: filter && {
+        '$and][0][store][slug': this.storeSlug,
+        '$or][0][title': filter,
+      } || {
+        '$and][0][store][slug': this.storeSlug,
+      },
+      populate: 'SEO.socialImage,Tags,cover',
     });
   }
 
@@ -80,7 +88,6 @@ export class StrapiClient {
       populate: 'SEO,SEO.socialImage,Tag,Thumbnail,Slides,stores'
     });
   }
-
   async getStore(slug = this.storeSlug) {
     return this.fetch<Store>({
       contentType: `stores`,

--- a/stories/docs.stories.tsx
+++ b/stories/docs.stories.tsx
@@ -1,13 +1,13 @@
-import { DocsGrid } from '../app/components/docs/grid';
+import { StoreGrid } from '../app/components/stores/grid';
 
 export default {
-  title: 'Components/DocsGrid',
-  component: DocsGrid,
+  title: 'Components/StoreGrid',
+  component: StoreGrid,
 };
 
 export const Default = {
   args: {
-    posts: [
+    stores: [
       {
         id: 1,
         title: 'Demo Store',

--- a/stories/docs.stories.tsx
+++ b/stories/docs.stories.tsx
@@ -10,15 +10,11 @@ export const Default = {
     stores: [
       {
         id: 1,
-        title: 'Demo Store',
+        Title: 'Demo Store',
         slug: 'demo',
         Description: 'A demo store',
-        Logo: {
-          data: {
-            attributes: {
-              url: 'https://placehold.co/600x400'
-            }
-          }
+        cover: {
+          url: 'https://placehold.co/600x400'
         }
       }
     ]


### PR DESCRIPTION
This pull request includes several changes to the `app/[slug]/page.tsx`, `markket/api.ts`, and related files to add support for displaying documentation and articles in addition to stores. The most important changes include adding new components for displaying documentation, modifying the API client to fetch posts, and updating the page logic to handle the new content type.

### Add support for documentation and articles:

* `app/[slug]/page.tsx`: Added imports for `DocsGrid` and updated the `getCollection` function to fetch posts when the key is 'docs'. Also, added conditional rendering for the `DocsGrid` component. ([app/[slug]/page.tsxR6](diffhunk://#diff-15b6ef6f25e71d012ef07cf98c566a5a214057ed1e4413960acc3845931fbda2R6), [app/[slug]/page.tsxL17-R23](diffhunk://#diff-15b6ef6f25e71d012ef07cf98c566a5a214057ed1e4413960acc3845931fbda2L17-R23), [app/[slug]/page.tsxR73-R81](diffhunk://#diff-15b6ef6f25e71d012ef07cf98c566a5a214057ed1e4413960acc3845931fbda2R73-R81))

### New components for documentation:

* [`app/components/docs/card.tsx`](diffhunk://#diff-e7dec2a56275715acf6d4f230ae1b59f0f3de51627525f6c5582f3aa40a7bcc8R1-R62): Introduced a new `BlogPostCard` component to display individual blog posts with title, content, publication date, and tags.
* [`app/components/docs/grid.tsx`](diffhunk://#diff-283a6a9f48af666840a7fae402fc9bb96c2a2fa8bd5df5f0477413d129255880R1-R18): Added a new `DocsGrid` component to display a grid of `BlogPostCard` components.

### API client modifications:

* [`markket/api.ts`](diffhunk://#diff-6b3d4ec35a69fd372335c964c961d76724f3cedb63af59ab5c69d1d75d0dbfeeL68-R80): Updated the `StrapiClient` class to include a new `getPosts` method for fetching articles with pagination and filtering options. [[1]](diffhunk://#diff-6b3d4ec35a69fd372335c964c961d76724f3cedb63af59ab5c69d1d75d0dbfeeL68-R80) [[2]](diffhunk://#diff-6b3d4ec35a69fd372335c964c961d76724f3cedb63af59ab5c69d1d75d0dbfeeL83)

### Storybook updates:

* [`stories/docs.stories.tsx`](diffhunk://#diff-c4818fdcdc9b43eb1f9b9722a84782eb854d4f1a5a22f20d3f822f63a2857ab3R1-R22): Added a new story for the `StoreGrid` component.
* [`stories/stores.stories.tsx`](diffhunk://#diff-c56b8be042cba08cc0cb6f8e29586a24ced006db99634fa9c386d9eed7901d05L1-R10): Updated the story to use `DocsGrid` instead of `StoreGrid`.