### PR TITLE
added URLS to store home

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,5 +1,3 @@
-
-
 'use client';
 
 import {
@@ -17,14 +15,43 @@ import {
   IconUserPlus,
   IconLogin,
   IconKey,
-  IconHomeHeart
+  IconHomeHeart,
+  IconLogout,
+  IconDashboard
 } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@/app/providers/auth';
 
 export default function AuthPage() {
   const router = useRouter();
+  const { maybe, logout } = useAuth();
+  const isLoggedIn = maybe();
 
-  const authOptions = [
+  const loggedInOptions = [
+    {
+      title: 'Dashboard',
+      description: 'Go to your dashboard',
+      icon: IconDashboard,
+      action: () => router.push('/dashboard/store'),
+      variant: 'filled',
+    },
+    {
+      title: 'Homepage',
+      description: 'Not all those who wander are lost',
+      icon: IconHomeHeart,
+      action: () => router.push('/'),
+      variant: 'subtle',
+    },
+    {
+      title: 'Sign Out',
+      description: 'See you soon!',
+      icon: IconLogout,
+      action: () => logout(),
+      variant: 'light',
+    },
+  ];
+
+  const loggedOutOptions = [
     {
       title: 'Sign In',
       description: 'Access your store and manage your products',
@@ -55,17 +82,19 @@ export default function AuthPage() {
     },
   ];
 
+  const options = isLoggedIn ? loggedInOptions : loggedOutOptions;
+
   return (
     <Container size={480} my={40}>
       <Title ta="center" fw={900}>
         Welcome to de.Markkët
       </Title>
       <Text c="dimmed" size="sm" ta="center" mt="sm">
-        Choose an option to continue
+        {isLoggedIn ? 'What would you like to do?' : 'Choose an option to continue'}
       </Text>
 
       <Stack mt={30}>
-        {authOptions.map((option, index) => (
+        {options.map((option, index) => (
           <Paper
             key={index}
             withBorder
@@ -105,4 +134,4 @@ export default function AuthPage() {
       </Stack>
     </Container>
   );
-}
+};

--- a/app/components/ui/store.tabs.tsx
+++ b/app/components/ui/store.tabs.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Tabs, Stack, Text } from "@mantine/core";
+import { NavLink } from "@mantine/core";
+
+interface StoreTabProps {
+  urls?: { id: number; Label: string; URL: string }[];
+}
+
+export function StoreTabs({ urls = [] }: StoreTabProps) {  // Default empty array
+
+  return (
+    <Tabs defaultValue="links">
+      <Tabs.List>
+        <Tabs.Tab value="links">Links</Tabs.Tab>
+        <Tabs.Tab value="contact">Contact Info</Tabs.Tab>
+        <Tabs.Tab value="addresses">Addresses</Tabs.Tab>
+      </Tabs.List>
+
+      <Tabs.Panel value="links">
+        {urls.length > 0 ? (
+          <Stack>
+            {urls.map((link) => (
+              <NavLink
+                key={link.id}
+                label={link.Label}
+                component="a"
+                href={link.URL}
+                target="_blank"
+              />
+            ))}
+          </Stack>
+        ) : (
+          <Text>No links available</Text>
+        )}
+      </Tabs.Panel>
+
+      <Tabs.Panel value="contact"><Text>Contact info coming soon</Text></Tabs.Panel>
+      <Tabs.Panel value="addresses"><Text>Addresses coming soon</Text></Tabs.Panel>
+    </Tabs>
+  );
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,23 +1,115 @@
-import { Metadata } from "next";
+'use client';
 
-export function generateMetadata(): Metadata {
-  return {
-    robots: {
-      index: false,
-      follow: false,
-    }
-  };
+import { markketClient } from '@/markket/api';
+import { useEffect, useState } from 'react';
+// import { Paper, Select, Group, Avatar, Text } from '@mantine/core';
+import { Store } from '@/markket/store';
+
+type StoreOption = {
+  value: string;
+  label: string;
+  image: string | undefined;
+  slug: string;
 };
 
-export default function DashboardRootLayout({
+export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const [stores, setStores] = useState<Store[]>([]);
+  const [selectedStore, setSelectedStore] = useState<string | null>(null);
+  const [, setStoreOptions] = useState<StoreOption[]>([]);
+  const [, setStore] = useState<Store | null>(null);
+
+  useEffect(() => {
+    setStoreOptions(stores.map((store) => ({
+      value: store.id.toString(),
+      label: store.title,
+      image: store.Favicon?.url || store.Logo.formats.small.url,
+      slug: store.slug,
+    })));
+  }, [stores]);
+
+  useEffect(() => {
+
+    if (!selectedStore) return;
+
+    const store = stores.find((s) => s.id.toString() === selectedStore);
+
+    if (store) {
+      setStore(store);
+    }
+  }, [selectedStore, stores]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const getStores = async () => {
+    const markket = new markketClient();
+    try {
+      const stores = await markket.fetch('/api/markket/store', {});
+      setStores(stores?.data || []);
+
+      if (stores?.data?.[0]) {
+        setSelectedStore(stores.data[0].id.toString());
+      }
+    } catch (error) {
+      console.error('Failed to fetch stores:', error);
+    }
+  };
+
+  // const handleStoreChange = (storeId: string | null) => {
+  //   if (!storeId) return;
+
+  //   setSelectedStore(storeId);
+  //   const store = stores.find(s => s.id.toString() === storeId);
+  //   if (store) {
+  //     // Update URL with store slug
+  //     const newPath = pathname.replace(/\/dashboard\/(.+)/, `/dashboard/${store.slug}/$1`);
+  //     router.push(newPath);
+  //   }
+  // };
+
+  useEffect(() => {
+    getStores();
+  }, []);
 
   return (
     <>
-    {children}
+      {/* {stores.length > 0 && (
+        <Paper shadow="sm" p="md" withBorder mb="xl">
+          <Group justify="end" >
+            <Text size="sm" fw={500} c="dimmed">
+              {store?.title} |
+              Select Store
+            </Text>
+            <Select
+              value={selectedStore}
+              onChange={(value) => {
+                setSelectedStore(value);
+              }}
+              data={storeOptions}
+              placeholder="Choose store"
+              clearable={false}
+              maxDropdownHeight={400}
+              comboboxProps={{ withinPortal: true }}
+              renderOption={(item) => {
+                const storeItem = item as unknown as StoreOption;
+                return (
+                  <Group gap="sm">
+                    <Avatar
+                      src={storeItem.image}
+                      size={20}
+                      radius="xl"
+                    />
+                    <span>{storeItem.label}</span>
+                  </Group>
+                );
+              }}
+            />
+          </Group>
+        </Paper>
+      )} */}
+      {children}
     </>
   );
 };

--- a/app/store/[slug]/page.tsx
+++ b/app/store/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { Container, Title, Text, Stack, Group, Button } from "@mantine/core";
 import { IconNews, IconShoppingBag, IconFiles } from '@tabler/icons-react';
 import PageContent from '@/app/components/ui/page.content';
+import { StoreTabs } from '@/app/components/ui/store.tabs';
 
 import { generateSEOMetadata } from '@/markket/metadata';
 import { Store } from "@/markket/store.d";
@@ -89,6 +90,7 @@ export default async function StorePage({
           </Group>
         </div>
         <PageContent params={{ page: homePage }} />
+        <StoreTabs urls={store?.URLS} />
       </Stack>
     </Container>
   );

--- a/markket/store.d.ts
+++ b/markket/store.d.ts
@@ -16,6 +16,7 @@ export interface Store {
     url: string;
   },
   URLS: {
+    id: number;
     Label: string;
     URL: string;
   }[],

--- a/markket/store.d.ts
+++ b/markket/store.d.ts
@@ -11,6 +11,11 @@ export interface Store {
   STRIPE_CUSTOMER_ID: string;
   Logo: {
     url: string;
+    formats: {
+      small: {
+        url: string;
+      }
+    }
   };
   Favicon: {
     url: string;


### PR DESCRIPTION
This pull request includes significant updates to the `app/auth/page.tsx`, `app/dashboard/layout.tsx`, and `app/store/[slug]/page.tsx` files, as well as the addition of a new component in `app/components/ui/store.tabs.tsx`. The changes enhance the user experience by adding new options for logged-in users, integrating store tabs, and refactoring the dashboard layout to dynamically fetch and display store data.

Enhancements to the authentication page:

* Added new icons and options for logged-in users, including 'Dashboard', 'Homepage', and 'Sign Out'. The options displayed are now conditional based on the user's login status. [[1]](diffhunk://#diff-45334f1db8260fe02e98f01048518cee1353158a7dcccf7bdb915a2f3378a4f1L20-R54) [[2]](diffhunk://#diff-45334f1db8260fe02e98f01048518cee1353158a7dcccf7bdb915a2f3378a4f1R85-R97)

New component for store tabs:

* Introduced `StoreTabs` component to display links, contact info, and addresses in a tabbed interface. This component is used in the store page to provide additional navigation options. ([app/components/ui/store.tabs.tsxR1-R42](diffhunk://#diff-15853ec3e40c70c6471c712b99e744d21f890004fc7284e818d4eca3146e57abR1-R42), [app/store/[slug]/page.tsxR93](diffhunk://#diff-a167422f634cc4eca2b9e3d45ba3cedd9f738722435970ad296ff4b9c6deb7d9R93))

Refactoring of the dashboard layout:

* Refactored `DashboardLayout` to fetch and manage store data dynamically. This includes fetching stores from an API, setting the selected store, and preparing store options for selection.

Integration of store tabs in the store page:

* Added `StoreTabs` to the store page to display relevant links associated with the store, enhancing the navigation and user experience. ([app/store/[slug]/page.tsxR7](diffhunk://#diff-a167422f634cc4eca2b9e3d45ba3cedd9f738722435970ad296ff4b9c6deb7d9R7), [app/store/[slug]/page.tsxR93](diffhunk://#diff-a167422f634cc4eca2b9e3d45ba3cedd9f738722435970ad296ff4b9c6deb7d9R93))

Also changed /auth page 

<img width="538" alt="Screenshot 2025-02-27 at 12 50 39 AM" src="https://github.com/user-attachments/assets/8a06504a-c5ce-4d73-be61-2348a569fa58" />
