### PR TITLE
Create store form 

### DIFF
--- a/app/api/markket/store/route.ts
+++ b/app/api/markket/store/route.ts
@@ -477,12 +477,15 @@ export async function POST(request: Request) {
  *       500:
  *         description: Internal server error
  */
-export async function PUT(request: Request, { params }: { params: { id: string } }) {
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+
+  const { id } = await params;
+
   try {
-    const userData = await validateUserAndToken(request);
+    const userData = await validateUserAndToken();
     const stores = await fetchUserStores(userData.id);
 
-    const storeExists = stores.data.some((store: any) => store.id.toString() === params.id);
+    const storeExists = stores.data.some((store: any) => store.id.toString() === id);
 
     if (!storeExists) {
       return NextResponse.json(
@@ -507,7 +510,7 @@ export async function PUT(request: Request, { params }: { params: { id: string }
       );
     }
 
-    const url = new URL(`api/stores/${params.id}`, STRAPI_URL);
+    const url = new URL(`api/stores/${id}`, STRAPI_URL);
     const client = new markketClient();
     const response = await client.fetch(url.toString(), {
       method: 'PUT',

--- a/app/api/markket/store/route.ts
+++ b/app/api/markket/store/route.ts
@@ -5,6 +5,12 @@ import qs from 'qs';
 const STRAPI_URL = process.env.NEXT_PUBLIC_MARKKET_API || 'https://api.markket.place/';
 const ADMIN_TOKEN = process.env.MARKKET_API_KEY;
 
+interface CreateStorePayload {
+  title: string;
+  Description: string;
+  slug: string;
+}
+
 async function verifyToken(token: string) {
   const _url = new URL('api/users/me', STRAPI_URL);
 
@@ -62,6 +68,57 @@ async function fetchUserStores(userId: number) {
     throw error;
   }
 }
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Store:
+ *       type: object
+ *       properties:
+ *         data:
+ *           type: object
+ *           properties:
+ *             id:
+ *               type: number
+ *               example: 1
+ *             title:
+ *               type: string
+ *               example: "Makeup store"
+ *             Description:
+ *               type: string
+ *               example: "For clowns and actors"
+ *             slug:
+ *               type: string
+ *               example: "makeup-clowns"
+ *             documentId:
+ *               type: string
+ *               example: "abc123xyz789"
+ *             createdAt:
+ *               type: string
+ *               format: date-time
+ *             Logo:
+ *               type: object
+ *               properties:
+ *                 url:
+ *                   type: string
+ *             Favicon:
+ *               type: object
+ *               properties:
+ *                 url:
+ *                   type: string
+ *             SEO:
+ *               type: object
+ *               properties:
+ *                 metaTitle:
+ *                   type: string
+ *                 metaDescription:
+ *                   type: string
+ *             URLS:
+ *               type: array
+ *               items:
+ *                 type: string
+ */
 
 /**
  * @swagger
@@ -170,6 +227,149 @@ export async function GET() {
     return NextResponse.json(stores);
   } catch (error) {
     console.error('Route error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+};
+
+
+/**
+ * @swagger
+ * /api/markket/store:
+ *   post:
+ *     summary: Create a new store
+ *     description: |
+ *       Creates a new store for the authenticated user.
+ *       Requires a valid JWT token in the Authorization header.
+ *       Uses admin token to create store in Strapi.
+ *     tags:
+ *       - Stores
+ *     security:
+ *       - BearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *               - Description
+ *               - slug
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: "Makeup store"
+ *               Description:
+ *                 type: string
+ *                 example: "For clowns and actors"
+ *               slug:
+ *                 type: string
+ *                 minLength: 5
+ *                 pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+ *                 example: "makeup-clowns"
+ *     responses:
+ *       201:
+ *         description: Store created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Store'
+ *       400:
+ *         description: Invalid request payload
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: "Invalid slug format"
+ *       401:
+ *         description: Authentication error
+ *       500:
+ *         description: Internal server error
+ */
+export async function POST(request: Request) {
+  if (!STRAPI_URL || !ADMIN_TOKEN) {
+    return NextResponse.json(
+      { error: 'API configuration missing' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // Verify user's JWT
+    const headersList = headers();
+    const token = headersList.get('authorization')?.split('Bearer ')[1];
+
+    if (!token) {
+      return NextResponse.json(
+        { error: 'No token provided' },
+        { status: 401 }
+      );
+    }
+
+    const userData = await verifyToken(token);
+    if (!userData) {
+      return NextResponse.json(
+        { error: 'Invalid token' },
+        { status: 401 }
+      );
+    }
+
+    // Validate request body
+    const payload: CreateStorePayload = await request.json();
+
+    if (!payload.title || !payload.Description || !payload.slug) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    if (payload.slug.length < 5) {
+      return NextResponse.json(
+        { error: 'Slug must be at least 5 characters' },
+        { status: 400 }
+      );
+    }
+
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(payload.slug)) {
+      return NextResponse.json(
+        { error: 'Invalid slug format' },
+        { status: 400 }
+      );
+    }
+
+    // Create store in Strapi
+    const response = await fetch(`${STRAPI_URL}/api/stores`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${ADMIN_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        data: {
+          ...payload,
+          users: [userData.id],
+          active: true,
+        }
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create store');
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data, { status: 201 });
+
+  } catch (error) {
+    console.error('Store creation error:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -23,6 +23,8 @@ import {
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/app/providers/auth';
 
+const STRAPI_URL = process.env.NEXT_PUBLIC_MARKKET_API || 'https://api.markket.place';
+
 export default function AuthPage() {
   const router = useRouter();
   const { maybe, logout } = useAuth();
@@ -72,7 +74,6 @@ export default function AuthPage() {
       description: 'Sign in or create an account using GitHub',
       icon: IconBrandGithub,
       action: () => {
-        const STRAPI_URL = process.env.NEXT_PUBLIC_MARKKET_API;
         const url = new URL(`/api/connect/github`, STRAPI_URL);
         window.location.href = url.toString();
       },

--- a/app/components/dashboard/settings.page.tsx
+++ b/app/components/dashboard/settings.page.tsx
@@ -57,7 +57,7 @@ const settingsTabs = [
  * @returns {JSX.Element}
  */
 export default function SettingsPage() {
-  const { user, stores } = useAuth();
+  const { user, stores, fetchStores } = useAuth();
   const [activeTab, setActiveTab] = useState('profile');
   const [showStoreForm, setShowStoreForm] = useState(false);
 
@@ -159,7 +159,10 @@ export default function SettingsPage() {
                 {showStoreForm && (
                   stores?.length >= 2 ?
                     (<></>) :
-                    (<StoreForm />)
+                    (<StoreForm onSubmit={() => {
+                      fetchStores();
+                      setShowStoreForm(false);
+                    }} />)
                 )}
 
                 {stores.length > 0 && (

--- a/app/components/dashboard/settings.page.tsx
+++ b/app/components/dashboard/settings.page.tsx
@@ -7,6 +7,7 @@ import {
   Paper,
   Text,
   Group,
+  Button,
   Avatar,
   Title,
   Stack,
@@ -20,6 +21,9 @@ import {
   IconBell,
   IconKey
 } from '@tabler/icons-react';
+
+import StoreForm from '@/app/components/ui/store.form';
+import Link from 'next/link';
 
 const settingsTabs = [
   {
@@ -48,9 +52,14 @@ const settingsTabs = [
   },
 ];
 
+/**
+ * Dashboard/settings page
+ * @returns {JSX.Element}
+ */
 export default function SettingsPage() {
-  const { user } = useAuth();
+  const { user, stores } = useAuth();
   const [activeTab, setActiveTab] = useState('profile');
+  const [showStoreForm, setShowStoreForm] = useState(false);
 
   // Handle hash-based navigation
   useEffect(() => {
@@ -129,8 +138,47 @@ export default function SettingsPage() {
               <Stack>
                 <Title order={4}>Store Settings</Title>
                 <Text size="sm" c="dimmed" maw={600}>
-                  Configure your store preferences and settings.
                 </Text>
+                <Group justify="space-between" align="center">
+                  {stores?.length < 2 ? (
+                    <>
+                      <Text>You can create up to two stores</Text>
+                      <Button
+                        variant="light"
+                        onClick={() => setShowStoreForm(!showStoreForm)}
+                      >
+                        {showStoreForm ? 'Cancel' : 'Create New Store'}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Text><strong>{stores?.length} stores</strong></Text>
+                    </>
+                  )}
+                </Group>
+                {showStoreForm && (
+                  stores?.length >= 2 ?
+                    (<></>) :
+                    (<StoreForm />)
+                )}
+
+                {stores.length > 0 && (
+                  <Stack mt="xl">
+                    <Title order={5}>Your Stores</Title>
+                    {stores.map((store) => (
+                      <Paper key={store.id} withBorder p="md">
+                        <Group justify="space-between">
+                          <Text fw={500}>
+                            <Link href={`/store/${store.slug}`}>
+                              {store.title}
+                            </Link>
+                          </Text>
+                          <Badge>{store.slug}</Badge>
+                        </Group>
+                      </Paper>
+                    ))}
+                  </Stack>
+                )}
               </Stack>
             </Tabs.Panel>
 

--- a/app/components/dashboard/store.page.tsx
+++ b/app/components/dashboard/store.page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { markketClient } from '@/markket/api';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import {
   Container,
@@ -13,11 +14,12 @@ import {
   Grid,
   Card,
   Image,
+  Button,
   Badge,
   type ComboboxItem,
 } from '@mantine/core';
 import { Store } from '@/markket/store';
-import { IconBuildingStore, IconLink } from '@tabler/icons-react';
+import { IconBuildingStore, IconLink, IconEdit } from '@tabler/icons-react';
 
 type StoreOption = {
   value: string;
@@ -28,6 +30,7 @@ type StoreOption = {
 export default function StoreDashboardPage  ()   {
   const [ stores, setStores ] = useState<Store[]>([]);
   const [ store, setStore ] = useState<Store | null>(null);
+  const router = useRouter();
 
   const storeOptions: StoreOption[]= stores.map((s) => ({
     value: s.id.toString(),
@@ -66,12 +69,23 @@ export default function StoreDashboardPage  ()   {
 
   return (
     <Container size="lg" py="xl">
-      {stores.length > 0 && (
+
         <Paper shadow="sm" p="md" withBorder mb="xl">
           <Group justify="space-between">
+          <Group>
             <Text size="sm" fw={500} c="dimmed">
               Select Store
             </Text>
+          </Group>
+          <Group>
+            <Button
+              variant="light"
+              size="sm"
+              leftSection={<IconEdit size={16} />}
+              onClick={() => router.push('/dashboard/settings#store')}
+            >
+              {!stores?.length ? 'Create ' : 'Manage '} Stores
+            </Button>
             <Select
               value={store?.id.toString()}
               onChange={handleStoreChange}
@@ -92,8 +106,8 @@ export default function StoreDashboardPage  ()   {
               )}
             />
           </Group>
-        </Paper>
-      )}
+        </Group>
+      </Paper>
 
       {store && (
         <Stack gap="xl">

--- a/app/components/ui/store.form.tsx
+++ b/app/components/ui/store.form.tsx
@@ -66,6 +66,7 @@ export default function StoreForm() {
 
       form.reset();
     } catch (error) {
+      console.warn({ error });
       notifications.show({
         title: 'Error',
         message: 'Failed to create store',
@@ -86,7 +87,7 @@ export default function StoreForm() {
           </Group>
 
           <Text size="sm" c="dimmed">
-            Fill out the form below to create a new store. The slug will be used in your store's URL.
+            Fill out the form below to create a new store. The slug will be used in your store&apos;s URL.
           </Text>
 
           <TextInput

--- a/app/components/ui/store.form.tsx
+++ b/app/components/ui/store.form.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  TextInput,
+  Textarea,
+  Button,
+  Group,
+  Stack,
+  Paper,
+  Text,
+  Title,
+} from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { notifications } from '@mantine/notifications';
+import { IconBuildingStore } from '@tabler/icons-react';
+
+interface StoreFormValues {
+  title: string;
+  Description: string;
+  slug: string;
+}
+
+export default function StoreForm() {
+  const [loading, setLoading] = useState(false);
+
+  const form = useForm<StoreFormValues>({
+    initialValues: {
+      title: '',
+      Description: '',
+      slug: '',
+    },
+    validate: {
+      title: (value) => (value.length < 3 ? 'Title must be at least 3 characters' : null),
+      slug: (value) => {
+        if (value.length < 5) return 'Slug must be at least 5 characters';
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+          return 'Slug can only contain lowercase letters, numbers, and hyphens';
+        }
+        return null;
+      },
+      Description: (value) => (value.length < 10 ? 'Description must be at least 10 characters' : null),
+    },
+  });
+
+  const handleSubmit = async (values: StoreFormValues) => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/markket/store', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(values),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create store');
+      }
+
+      notifications.show({
+        title: 'Success',
+        message: 'Store created successfully',
+        color: 'green',
+      });
+
+      form.reset();
+    } catch (error) {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to create store',
+        color: 'red',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Paper withBorder p="md" radius="md">
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <Stack>
+          <Group>
+            <IconBuildingStore size={24} />
+            <Title order={3}>Create New Store</Title>
+          </Group>
+
+          <Text size="sm" c="dimmed">
+            Fill out the form below to create a new store. The slug will be used in your store's URL.
+          </Text>
+
+          <TextInput
+            label="Store Name"
+            placeholder="My Awesome Store"
+            required
+            {...form.getInputProps('title')}
+          />
+
+          <TextInput
+            label="Store Slug"
+            placeholder="my-awesome-store"
+            description="This will be your store's URL: markket.place/store/[slug]"
+            required
+            {...form.getInputProps('slug')}
+          />
+
+          <Textarea
+            label="Description"
+            placeholder="Tell us about your store..."
+            required
+            minRows={3}
+            {...form.getInputProps('Description')}
+          />
+
+          <Group justify="flex-end">
+            <Button
+              type="submit"
+              loading={loading}
+              leftSection={<IconBuildingStore size={16} />}
+            >
+              Create Store
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Paper>
+  );
+};

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -42,7 +42,6 @@ export default function DashboardLayout({
     }
   }, [selectedStore, stores]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const getStores = async () => {
     const markket = new markketClient();
     try {

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -24,10 +24,10 @@ export default function DashboardLayout({
 
   useEffect(() => {
     setStoreOptions(stores.map((store) => ({
-      value: store.id.toString(),
-      label: store.title,
-      image: store.Favicon?.url || store.Logo.formats.small.url,
-      slug: store.slug,
+      value: store?.id?.toString(),
+      label: store?.title,
+      image: store?.Favicon?.url || store?.Logo?.formats?.small?.url,
+      slug: store?.slug,
     })));
   }, [stores]);
 

--- a/app/providers/auth.tsx
+++ b/app/providers/auth.tsx
@@ -4,7 +4,6 @@ import { createContext, useContext, useState, useEffect, useCallback } from 'rea
 import { useRouter } from 'next/navigation';
 import { strapiClient, markketClient } from '@/markket/api';
 import { Store } from '@/markket/store'
-import { resourceLimits } from 'worker_threads';
 
 interface User {
   id: number;
@@ -53,7 +52,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const [stores, setStores] = useState<Store[]>([]);
 
-  const fetchStores = async () => {
+  const fetchStores = useCallback(async () => {
     if (!maybe()) return;
 
     try {
@@ -64,7 +63,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } catch (error) {
       console.error('Failed to fetch stores:', error);
     }
-  };
+  }, []);
 
   const logout = useCallback(() => {
     setUser(null);
@@ -103,7 +102,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       fetchStores();
     }
 
-  }, [user?.id]);
+  }, [user?.id, fetchStores]);
 
   const refreshUser = async () => {
     await verifyAndRefreshUser();

--- a/markket/config.ts
+++ b/markket/config.ts
@@ -1,0 +1,6 @@
+/**
+ * Runtime configuration for the Markket app
+ */
+export const markketConfig = {
+  max_stores_per_user: 2,
+};


### PR DESCRIPTION
Created wrapper endpoint to POST & PUT store information 

Users with 2 stores or less can create a store 

We'll implement better limits after subscription models and payments

The user.jwt is used to confirm the user is valid, and then we use the ADMIN tokens to send data 

Created form components & tab in dashboard 