### PR TITLE
abstracted store buttons into a separate component

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -35,8 +35,9 @@ const STRAPI_URL = process.env.NEXT_PUBLIC_MARKKET_API || 'https://api.markket.p
  */
 export default function AuthPage() {
   const router = useRouter();
-  const { maybe, logout } = useAuth();
+  const { maybe, logout, confirmed } = useAuth();
   const isLoggedIn = maybe();
+  const isConfirmed = confirmed();
   const [store, setStore] = useState({} as Store);
 
   useEffect(() => {
@@ -120,9 +121,17 @@ export default function AuthPage() {
       <Title ta="center" fw={900}>
         Welcome to {store?.title || 'Markket.ts'}!
       </Title>
+
       <Text c="dimmed" size="sm" ta="center" mt="sm">
         {isLoggedIn ? 'What would you like to do?' : 'Choose an option to continue'}
       </Text>
+
+      {!isConfirmed && (
+        <Text c="red" ta="center" mt="sm">
+          Please confirm your email address to view the dashboard,
+          logout and retry if this message persists.
+        </Text>
+      )}
 
       <Stack mt={30}>
         {options.map((option, index) => (

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -126,7 +126,7 @@ export default function AuthPage() {
         {isLoggedIn ? 'What would you like to do?' : 'Choose an option to continue'}
       </Text>
 
-      {!isConfirmed && (
+      {isLoggedIn && !isConfirmed && (
         <Text c="red" ta="center" mt="sm">
           Please confirm your email address to view the dashboard,
           logout and retry if this message persists.

--- a/app/components/dashboard/store.page.tsx
+++ b/app/components/dashboard/store.page.tsx
@@ -49,7 +49,7 @@ export default function StoreDashboardPage  ()   {
     try {
       const stores = await markket.fetch('/api/markket/store ', {});
       setStores(stores?.data || []);
-      setStore(stores?.data[0] || null);
+      setStore(stores?.data?.[0] || null);
 
     } catch (error) {
       console.error('Failed to fetch stores:', error);

--- a/app/components/layout/store.layout.tsx
+++ b/app/components/layout/store.layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AppShell, Burger, Container, Group, Button, Text, Stack } from "@mantine/core";
-import { IconHome, IconShoppingCart, IconArticle, IconInfoCircle, IconArrowLeft } from "@tabler/icons-react";
+import { IconHome, IconShoppingCart, IconLockBolt, IconArticle, IconInfoCircle, IconArrowLeft } from "@tabler/icons-react";
 import Link from "next/link";
 import { useDisclosure } from '@mantine/hooks';
 import { Store } from '@/markket/store.d';
@@ -17,7 +17,7 @@ function StoreNavigation({ slug, onNavigate }: { slug: string; onNavigate?: () =
             fullWidth
             className="justify-start h-12"
           >
-            Home
+            Store Home
           </Button>
         </Link>
         <Link href={`/store/${slug}/products`} onClick={onNavigate}>
@@ -71,6 +71,16 @@ function StoreNavigation({ slug, onNavigate }: { slug: string; onNavigate?: () =
             className="justify-start h-12"
           >
             Markkët Home
+          </Button>
+        </Link>
+        <Link href="/auth" onClick={onNavigate}>
+          <Button
+            variant="light"
+            leftSection={<IconLockBolt size={18} />}
+            fullWidth
+            className="justify-start h-12"
+          >
+            Auth Page
           </Button>
         </Link>
       </Stack>

--- a/app/components/ui/store.header.buttons.tsx
+++ b/app/components/ui/store.header.buttons.tsx
@@ -1,0 +1,40 @@
+import { Button, Group } from '@mantine/core';
+import { IconNews, IconShoppingBag, IconFiles } from '@tabler/icons-react';
+import { Store } from '@/markket/store.d';
+
+type StoreHeaderButtonsProps = {
+  store: Store;
+};
+
+const StoreHeaderButtons = ({ store }: StoreHeaderButtonsProps) => {
+  return (
+    <Group justify="center" gap="md" className='py-10'>
+      <Button
+        component="a"
+        href={`/store/${store.slug}/blog`}
+        variant="light"
+        leftSection={<IconNews size={20} />}
+      >
+        Blog
+      </Button>
+      <Button
+        component="a"
+        href={`/store/${store.slug}/products`}
+        variant="light"
+        leftSection={<IconShoppingBag size={20} />}
+      >
+        Products
+      </Button>
+      <Button
+        component="a"
+        href={`/store/${store.slug}/about`}
+        variant="light"
+        leftSection={<IconFiles size={20} />}
+      >
+        Pages
+      </Button>
+    </Group>
+  );
+};
+
+export default StoreHeaderButtons;

--- a/app/components/ui/store.header.buttons.tsx
+++ b/app/components/ui/store.header.buttons.tsx
@@ -1,5 +1,5 @@
 import { Button, Group } from '@mantine/core';
-import { IconNews, IconShoppingBag, IconFiles } from '@tabler/icons-react';
+import { IconNews, IconShoppingBag, IconFiles, IconOctahedronPlus } from '@tabler/icons-react';
 import { Store } from '@/markket/store.d';
 
 type StoreHeaderButtonsProps = {
@@ -8,7 +8,15 @@ type StoreHeaderButtonsProps = {
 
 const StoreHeaderButtons = ({ store }: StoreHeaderButtonsProps) => {
   return (
-    <Group justify="center" gap="md" className='py-10'>
+    <Group justify="center" gap="md" className='py-12'>
+      <Button
+        component="a"
+        href={`/store/${store.slug}`}
+        variant="light"
+        leftSection={<IconOctahedronPlus size={20} />}
+      >
+        Home
+      </Button>
       <Button
         component="a"
         href={`/store/${store.slug}/blog`}
@@ -31,7 +39,7 @@ const StoreHeaderButtons = ({ store }: StoreHeaderButtonsProps) => {
         variant="light"
         leftSection={<IconFiles size={20} />}
       >
-        Pages
+        About
       </Button>
     </Group>
   );

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -32,14 +32,16 @@ export default function DashboardLayout({
     if (!x) {
       return router.replace('/auth');
     }
+  }, [confirmed, router]);
 
+  useEffect(() => {
     setStoreOptions(stores.map((store) => ({
       value: store?.id?.toString(),
       label: store?.title,
       image: store?.Favicon?.url || store?.Logo?.formats?.small?.url,
       slug: store?.slug,
     })));
-  }, [stores, confirmed, router]);
+  }, [stores]);
 
   useEffect(() => {
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -4,6 +4,8 @@ import { markketClient } from '@/markket/api';
 import { useEffect, useState } from 'react';
 // import { Paper, Select, Group, Avatar, Text } from '@mantine/core';
 import { Store } from '@/markket/store';
+import { useAuth } from '@/app/providers/auth';
+import { useRouter } from 'next/navigation';
 
 type StoreOption = {
   value: string;
@@ -22,14 +24,22 @@ export default function DashboardLayout({
   const [, setStoreOptions] = useState<StoreOption[]>([]);
   const [, setStore] = useState<Store | null>(null);
 
+  const { confirmed, } = useAuth();
+  const router = useRouter();
+
   useEffect(() => {
+    const x = confirmed();
+    if (!x) {
+      return router.replace('/auth');
+    }
+
     setStoreOptions(stores.map((store) => ({
       value: store?.id?.toString(),
       label: store?.title,
       image: store?.Favicon?.url || store?.Logo?.formats?.small?.url,
       slug: store?.slug,
     })));
-  }, [stores]);
+  }, [stores, confirmed, router]);
 
   useEffect(() => {
 

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -28,14 +28,9 @@ export default function DashboardLayout({
   const router = useRouter();
 
   useEffect(() => {
-    const pathname = window?.location?.pathname;
     const x = confirmed();
     if (!x) {
       return router.replace('/auth');
-    }
-
-    if (pathname === '/dashboard') {
-      return router.replace('/dashboard/store');
     }
 
     setStoreOptions(stores.map((store) => ({

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -28,9 +28,14 @@ export default function DashboardLayout({
   const router = useRouter();
 
   useEffect(() => {
+    const pathname = window?.location?.pathname;
     const x = confirmed();
     if (!x) {
       return router.replace('/auth');
+    }
+
+    if (pathname === '/dashboard') {
+      return router.replace('/dashboard/store');
     }
 
     setStoreOptions(stores.map((store) => ({

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 export default function DashboardHome() {
+
   return (
     <>
       redirecting....

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export default function DashboardHome() {
+  return (
+    <>
+      redirecting....
+    </>
+  );
+};

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,10 +1,104 @@
 'use client';
 
+import { Container, Title, Text, SimpleGrid, Paper, rem } from '@mantine/core';
+import {
+  IconBuildingStore,
+  IconSettings,
+  IconUserCircle,
+} from '@tabler/icons-react';
+import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
+
+interface DashboardCard {
+  title: string;
+  description: string;
+  icon: typeof IconBuildingStore;
+  color: string;
+  href: string;
+  iconColor?: string;
+}
+
+const dashboardCards: DashboardCard[] = [
+  {
+    title: 'Stores',
+    description: 'Manage your stores and products',
+    icon: IconBuildingStore,
+    color: 'blue',
+    href: '/dashboard/store',
+    iconColor: '#0067ff'
+  },
+  {
+    title: 'Settings',
+    description: 'New stores, and preferences',
+    icon: IconSettings,
+    color: 'pink',
+    iconColor: '#ff3366',
+    href: '/dashboard/settings'
+  },
+  {
+    title: 'Account',
+    description: 'Profile and authentication',
+    icon: IconUserCircle,
+    color: 'grape',
+    iconColor: '#fbda0f',
+    href: '/auth'
+  },
+];
+
 export default function DashboardHome() {
+  const router = useRouter();
 
   return (
-    <>
-      redirecting....
-    </>
+    <Container size="md" py="xl">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <Title order={1} mb="sm">Dashboard</Title>
+        <Text c="dimmed" mb="xl">
+          Store Management and Configuration
+        </Text>
+
+        <SimpleGrid
+          cols={{ base: 1, sm: 2, md: 3 }}
+          spacing="xl"
+          verticalSpacing="xl"
+        >
+          {dashboardCards.map((card, index) => (
+            <motion.div
+              key={card.title}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <Paper
+                shadow="md"
+                p="xl"
+                radius="md"
+                className={`
+                  cursor-pointer transition-all duration-200
+                  hover:shadow-lg hover:-translate-y-1
+                  bg-gradient-to-br from-${card.color}-50 to-white
+                `}
+                onClick={() => router.push(card.href)}
+              >
+                <card.icon
+                  size={rem(48)}
+                  color={card.iconColor}
+                  className={`text-${card.color}-500 mb-4`}
+                />
+                <Title order={3} mb="xs" size="h4">
+                  {card.title}
+                </Title>
+                <Text size="sm" c="dimmed">
+                  {card.description}
+                </Text>
+              </Paper>
+            </motion.div>
+          ))}
+        </SimpleGrid>
+      </motion.div>
+    </Container>
   );
 };

--- a/app/providers/auth.tsx
+++ b/app/providers/auth.tsx
@@ -27,6 +27,7 @@ interface AuthContextType {
   refreshUser: () => Promise<void>;
   stores: Store[];
   fetchStores: () => Promise<void>;
+  confirmed: () => boolean;
 }
 
 const AuthContext = createContext<AuthContextType>({
@@ -38,6 +39,7 @@ const AuthContext = createContext<AuthContextType>({
   refreshUser: async () => { },
   stores: [],
   fetchStores: async () => { },
+  confirmed: () => false,
 });
 
 /**
@@ -123,11 +125,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return !!_string;
   };
 
+  const confirmed = () => {
+    if (!localStorage) {
+      return false;
+    }
+
+    const _string = localStorage.getItem('markket.auth');
+
+    const _json = JSON.parse(_string || '{}');
+
+    return !!_json?.jwt;
+  };
+
   const value = {
     user,
     login,
     maybe,
     logout,
+    confirmed,
     isLoading,
     refreshUser,
     stores,

--- a/app/store/[slug]/about/page.tsx
+++ b/app/store/[slug]/about/page.tsx
@@ -7,6 +7,7 @@ import PageContent from '@/app/components/ui/page.content';
 import { generateSEOMetadata } from '@/markket/metadata';
 import { Page } from "@/markket/page";
 import { Metadata } from "next";
+import StoreHeaderButtons from '@/app/components/ui/store.header.buttons';
 
 interface AboutPageProps {
   params: Promise<{ slug: string }>;
@@ -51,8 +52,9 @@ export default async function AboutPage({ params }: AboutPageProps) {
   return (
     <Container size="lg" py="xl">
       <div className="text-center mb-12">
-        <Title className="mb-4">{aboutPage?.Title || `About ${store.SEO?.metaTitle}`}</Title>
+        <Title className="mb-4">{aboutPage?.Title || `About ${store.SEO?.metaTitle || store?.title}`}</Title>
       </div>
+      <StoreHeaderButtons store={store} />
       <div className="mb-6">
         {aboutPage?.Content ?
           (<PageContent params={{ page: aboutPage }} />) :

--- a/app/store/[slug]/blog/page.tsx
+++ b/app/store/[slug]/blog/page.tsx
@@ -8,6 +8,7 @@ import { generateSEOMetadata } from '@/markket/metadata';
 import { Page } from "@/markket/page";
 import { Metadata } from "next";
 import PageContent from "@/app/components/ui/page.content";
+import StoreHeaderButtons from "@/app/components/ui/store.header.buttons";
 
 interface BlogPageProps {
   params: Promise<{ slug: string }>;
@@ -27,12 +28,11 @@ export async function generateMetadata({ params }: BlogPageProps): Promise<Metad
     slug,
     entity: {
       SEO: page?.SEO,
-      title: page?.Title || 'Blog',
+      title: page?.Title || `${slug} Blog`,
       id: page?.id?.toString(),
       url: `/store/${slug}/blog`,
     },
-    type: 'article',
-    defaultTitle: `${page?.Title}` || 'Blog',
+    type: 'website',
   });
 };
 
@@ -54,16 +54,19 @@ export default async function StoreBlogPage({ params }: BlogPageProps) {
   }, {
     sort: 'createdAt:desc'
   }, slug);
+
   const posts = postsResponse?.data || [] as Article[];
-  const description = page?.SEO?.metaDescription || `Blog posts for ${store?.SEO?.metaTitle}`;
+
+  const description = page?.SEO?.metaDescription || `Blog posts for ${store?.title || store?.SEO?.metaTitle}`;
 
   return (
     <Container size="lg" py="xl">
       <Stack gap="xl">
         <div className="text-center">
           <Title order={1}>
-            {page?.Title || `Blog`}
+            {page?.Title || `${store?.title} Blog`}
           </Title>
+          <StoreHeaderButtons store={store} />
           <Text c="dimmed" size="lg">
             {description}
           </Text>

--- a/app/store/[slug]/page.tsx
+++ b/app/store/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { generateSEOMetadata } from '@/markket/metadata';
 import { Store } from "@/markket/store.d";
 import { Metadata } from "next";
 import StoreHeaderButtons from '@/app/components/ui/store.header.buttons';
+import { markketConfig } from '@/markket/config';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -50,7 +51,7 @@ export default async function StorePage({
       <Stack gap="xl">
         <div className="text-center">
           <img
-            src={store.Logo?.url}
+            src={store.Logo?.url || store?.SEO?.socialImage?.url || markketConfig.blank_image_url}
             alt={store.SEO?.metaTitle}
             width={200}
             height={200}

--- a/app/store/[slug]/page.tsx
+++ b/app/store/[slug]/page.tsx
@@ -1,14 +1,15 @@
 
 import { strapiClient } from '@/markket/api';
 import { notFound } from 'next/navigation';
-import { Container, Title, Text, Stack, Group, Button } from "@mantine/core";
-import { IconNews, IconShoppingBag, IconFiles } from '@tabler/icons-react';
+import { Container, Title, Text, Stack, } from "@mantine/core";
 import PageContent from '@/app/components/ui/page.content';
 import { StoreTabs } from '@/app/components/ui/store.tabs';
+import Markdown from '@/app/components/ui/page.markdown';
 
 import { generateSEOMetadata } from '@/markket/metadata';
 import { Store } from "@/markket/store.d";
 import { Metadata } from "next";
+import StoreHeaderButtons from '@/app/components/ui/store.header.buttons';
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -45,7 +46,7 @@ export default async function StorePage({
   }
 
   return (
-    <Container size="lg" className="py-20">
+    <Container size="lg" className="pb-20">
       <Stack gap="xl">
         <div className="text-center">
           <img
@@ -56,38 +57,16 @@ export default async function StorePage({
             className="mx-auto mb-8"
           />
           <Title className="text-4xl md:text-5xl mb-4">
-            {store.SEO?.metaTitle}
+            {store?.title || store?.SEO?.metaTitle}
           </Title>
-          <Text size="xl" c="dimmed" className="mx-auto mb-8">
-            {store.SEO?.metaDescription}
-          </Text>
 
-          <Group justify="center" gap="md">
-            <Button
-              component="a"
-              href={`/store/${store.slug}/blog`}
-              variant="light"
-              leftSection={<IconNews size={20} />}
-            >
-              Blog
-            </Button>
-            <Button
-              component="a"
-              href={`/store/${store.slug}/products`}
-              variant="light"
-              leftSection={<IconShoppingBag size={20} />}
-            >
-              Products
-            </Button>
-            <Button
-              component="a"
-              href={`/store/${store.slug}/about`}
-              variant="light"
-              leftSection={<IconFiles size={20} />}
-            >
-              Pages
-            </Button>
-          </Group>
+          <StoreHeaderButtons store={store} />
+
+          {store?.Description ?
+            <Markdown content={store.Description} /> :
+            (<Text size="xl" c="dimmed" className="mx-auto mb-8">
+              store?.SEO?.metaDescription</Text>)
+          }
         </div>
         <PageContent params={{ page: homePage }} />
         <StoreTabs urls={store?.URLS} />

--- a/app/store/[slug]/products/page.tsx
+++ b/app/store/[slug]/products/page.tsx
@@ -2,6 +2,8 @@ import { Product } from "@/markket/product.d";
 import { strapiClient } from "@/markket/api";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import StoreHeaderButtons from "@/app/components/ui/store.header.buttons";
+import Markdown from "@/app/components/ui/page.markdown";
 
 interface ProductPageProps {
   params: Promise<{ slug: string }>;
@@ -27,11 +29,10 @@ export default async function ProductPage({ params }: ProductPageProps) {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <div className="text-center mb-16">
         <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-          Our Products
+          {store?.title} Products
         </h1>
-        <p className="mt-4 text-xl text-gray-500">
-          Discover our unique collection
-        </p>
+        <StoreHeaderButtons store={store} />
+        <Markdown content={store?.Description} />
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "npm@9.8.1",
   "scripts": {
     "dev": "next dev  --port 4020 --turbopack",
+    "dev:api": "next dev  --port 4200 --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "packageManager": "npm@9.8.1",
   "scripts": {
     "dev": "next dev  --port 4020 --turbopack",
-    "dev:api": "next dev  --port 4200 --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
Creating a better experience when navigating stores, and after registration 

# store pages 

Created new component `app/components/ui/store.header.buttons` to abstract navigation buttons blog, pages & products 

# auth 

Creating `unconfirmed` method and wait page, to clarify allowed actions after register 

# npm 

Looking to create packages to separate utilities 
