### PR TITLE
New image endpoints for proxy and unsplash with accompanying modal usage 

### DIFF
--- a/app/api/markket/img/route.ts
+++ b/app/api/markket/img/route.ts
@@ -1,0 +1,102 @@
+
+import { markketConfig } from '@/markket/config';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * API extension endpoints for image interactions
+ *
+ * Enabled actions - proxy | unsplash -
+ *
+ * Proxy reads URL images to go around cross origin restrictions
+ * Unsplash queries their API for suggested images
+ *
+ * GET /api/markket/img?action=proxy&url=..
+ * GET /api/markket/img?action=unsplash&query=[keywords]
+ * @param req
+ * @returns
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const action = searchParams.get('action');
+
+  if (action === 'proxy') {
+    const url = searchParams.get('url');
+    // If url is not a valid URL, treat as Unsplash search query
+    if (!url) {
+      return NextResponse.json({ error: 'Invalid or missing url' }, { status: 400 });
+    }
+
+    if (!/^https?:\/\//.test(url)) {
+      try {
+        const imgRes = await fetch(url, { headers: { 'User-Agent': 'markketplace-proxy' } });
+        if (!imgRes.ok) {
+          return NextResponse.json({ error: 'Failed to fetch image' }, { status: 502 });
+        }
+
+        const contentType = imgRes.headers.get('content-type') || 'image/jpeg';
+        const arrayBuffer = await imgRes.arrayBuffer();
+
+        return new NextResponse(Buffer.from(arrayBuffer), {
+          status: 200,
+          headers: {
+            'Content-Type': contentType,
+            'Access-Control-Allow-Origin': '*',
+            'Cache-Control': 'public, max-age=3600',
+          },
+        });
+      } catch (e) {
+        return NextResponse.json({ error: 'Image proxy error', message: e }, { status: 500 });
+      }
+    }
+
+    try {
+      const imgRes = await fetch(url, { headers: { 'User-Agent': 'markketplace-proxy' } });
+      if (!imgRes.ok) {
+        return NextResponse.json({ error: 'Failed to fetch image' }, { status: 502 });
+      }
+      const contentType = imgRes.headers.get('content-type') || 'image/jpeg';
+      const arrayBuffer = await imgRes.arrayBuffer();
+
+      return new NextResponse(Buffer.from(arrayBuffer), {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'public, max-age=3600',
+        },
+      });
+    } catch (e) {
+      return NextResponse.json({ error: 'Proxy error', message: e }, { status: 500 });
+    }
+  }
+
+  if (action === 'unsplash') {
+    const accessKey = markketConfig.extensions?.unsplash_access_key;
+    if (!accessKey) {
+      return NextResponse.json({ error: 'Unsplash access key not set' }, { status: 500 });
+    }
+
+    const query = searchParams.get('query');
+
+    try {
+      const url = query
+        ? `https://api.unsplash.com/photos/random?count=10&orientation=squarish&query=${encodeURIComponent(query)}&client_id=${accessKey}`
+        : `https://api.unsplash.com/photos/random?count=10&orientation=squarish&client_id=${accessKey}`;
+
+      const unsplashRes = await fetch(url);
+      if (!unsplashRes.ok) {
+        return NextResponse.json({ error: 'Failed to fetch Unsplash images' }, { status: 502 });
+      }
+      const data = await unsplashRes.json();
+      const urls = Array.isArray(data)
+        ? data.map((img: any) => img.urls?.regular || img.urls?.full || img.urls?.small)
+        : [];
+
+      return NextResponse.json({ urls });
+    } catch (e) {
+      return NextResponse.json({ error: 'Unsplash error', message: e }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+}

--- a/app/components/dashboard/image.modal.tsx
+++ b/app/components/dashboard/image.modal.tsx
@@ -2,10 +2,12 @@ import { useState, useEffect } from 'react';
 import {
   Modal, Stack, SegmentedControl, Paper, Text, Center, Loader, TextInput, Button, Group, FileButton, Progress, ActionIcon, Box, Image as MantineImage
 } from '@mantine/core';
-import { IconLink, IconUpload, IconFileUpload, IconX, IconPhotoPlus, } from '@tabler/icons-react';
+import { IconLink, IconUpload, IconFileUpload, IconX, IconPhotoPlus, IconDownload, IconSparkles } from '@tabler/icons-react';
 import { Dropzone } from '@mantine/dropzone';
+import { useMediaQuery } from '@mantine/hooks';
+import { markketConfig } from '@/markket/config';
 
-const PLACEHOLDER = 'https://markketplace.nyc3.digitaloceanspaces.com/uploads/079a9ce3daa373036a6bc77c1739d424.png';
+const PLACEHOLDER = markketConfig.blank_image_url;
 
 type ImageModalProps = {
   imageModalOpen: boolean;
@@ -17,6 +19,7 @@ type ImageModalProps = {
   onInsert?: (img: { url: string; alt: string }) => void;
   mode?: 'preview' | 'replace';
   onToggleMode?: () => void;
+  disableReplace?: boolean;
 };
 
 const ImageModal = ({
@@ -28,6 +31,7 @@ const ImageModal = ({
   onReplace,
   mode = 'preview',
   onToggleMode,
+  disableReplace = false, // NEW PROP
 }: ImageModalProps) => {
   const [imageUploadOption, setImageUploadOption] = useState<'url' | 'upload'>('upload');
   const [imageUrl, setImageUrl] = useState(initialImageUrl);
@@ -36,6 +40,10 @@ const ImageModal = ({
   const [previewUrl, setPreviewUrl] = useState('');
   const [uploadProgress, setUploadProgress] = useState(0);
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const [unsplashLoading, setUnsplashLoading] = useState(false);
+  const [finishing, setFinishing] = useState(false);
+  const isMobile = useMediaQuery('(max-width: 600px)');
 
   useEffect(() => {
     if (imageModalOpen) {
@@ -84,6 +92,107 @@ const ImageModal = ({
     };
   };
 
+  // Helper to load/process image from URL
+  const handleLoadFromUrlProxy = async (proxyUrl: string) => {
+    setUrlError(null);
+
+    try {
+      const img = new window.Image();
+      img.crossOrigin = 'anonymous';
+      img.src = proxyUrl;
+      img.onload = async function () {
+        const width = img.width;
+        const height = img.height;
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        if (maxWidth && width > maxWidth) {
+          const ratio = maxWidth / (width < 1 ? 1 : width);
+          canvas.width = width * ratio + .5 | 0;
+          canvas.height = height * ratio + .5 | 0;
+          ctx?.drawImage(img, 0, 0, canvas.width, canvas.height);
+          const blob = await new Promise<Blob>(rs => canvas.toBlob(rs as any, 'image/png'));
+          const file = new File([blob], 'unsplash-image.png', { type: 'image/png' });
+          setImageFile(file);
+          setPreviewUrl(URL.createObjectURL(file));
+        } else {
+          canvas.width = width;
+          canvas.height = height;
+          ctx?.drawImage(img, 0, 0);
+          const blob = await new Promise<Blob>(rs => canvas.toBlob(rs as any, 'image/png'));
+          const file = new File([blob], 'unsplash-image.png', { type: 'image/png' });
+          setImageFile(file);
+          setPreviewUrl(URL.createObjectURL(file));
+        }
+        setImageUploadOption('upload');
+      };
+      img.onerror = () => {
+        setUrlError('Could not load Unsplash image.');
+      };
+    } catch {
+      setUrlError('Could not load Unsplash image.');
+    }
+  };
+
+  /** When the input has keywords, pull from the unsplash endpoint */
+  const handleRandomUnsplash = async () => {
+    setUnsplashLoading(true);
+    setUrlError(null);
+
+    try {
+      const query = imageUrl && !/^https?:\/\//.test(imageUrl) ? imageUrl : '';
+
+      const endpoint = query
+        ? `/api/markket/img?action=unsplash&query=${encodeURIComponent(query)}`
+        : '/api/markket/img?action=unsplash';
+      const res = await fetch(endpoint);
+      const data = await res.json();
+
+      if (data.urls && data.urls.length > 0) {
+        // Use Unsplash image URL directly (no proxy needed)
+        const url = data.urls[Math.floor(Math.random() * data.urls.length)];
+        setImageUrl(url);
+        // Load as preview (simulate upload)
+        const img = new window.Image();
+        img.crossOrigin = 'anonymous';
+        img.src = url;
+        img.onload = async function () {
+          const width = img.width;
+          const height = img.height;
+          const canvas = document.createElement('canvas');
+          const ctx = canvas.getContext('2d');
+          if (maxWidth && width > maxWidth) {
+            const ratio = maxWidth / (width < 1 ? 1 : width);
+            canvas.width = width * ratio + .5 | 0;
+            canvas.height = height * ratio + .5 | 0;
+            ctx?.drawImage(img, 0, 0, canvas.width, canvas.height);
+            const blob = await new Promise<Blob>(rs => canvas.toBlob(rs as any, 'image/png'));
+            const file = new File([blob], 'unsplash-image.png', { type: 'image/png' });
+            setImageFile(file);
+            setPreviewUrl(URL.createObjectURL(file));
+          } else {
+            canvas.width = width;
+            canvas.height = height;
+            ctx?.drawImage(img, 0, 0);
+            const blob = await new Promise<Blob>(rs => canvas.toBlob(rs as any, 'image/png'));
+            const file = new File([blob], 'unsplash-image.png', { type: 'image/png' });
+            setImageFile(file);
+            setPreviewUrl(URL.createObjectURL(file));
+          }
+          setImageUploadOption('upload');
+        };
+        img.onerror = () => {
+          setUrlError('Could not load Unsplash image.');
+        };
+      } else {
+        setUrlError('No Unsplash images found.');
+      }
+    } catch {
+      setUrlError('Could not fetch Unsplash image.');
+    } finally {
+      setUnsplashLoading(false);
+    }
+  };
+
   const resetFileInput = () => {
     setIsUploading(false);
     setPreviewUrl('');
@@ -93,61 +202,110 @@ const ImageModal = ({
 
   const handleReplaceImage = () => {
     setIsUploading(true);
-    setUploadProgress(33);
+    setFinishing(false);
+    setUploadProgress(10 + Math.floor(Math.random() * 20)); // Start at 10-30%
+
+    let uploadDone = false;
+    const finish = () => {
+      uploadDone = true;
+      setFinishing(false);
+      setIsUploading(false);
+      setUploadProgress(100);
+    };
 
     if (onReplace) {
       if (imageUploadOption == 'url' && initialImageUrl.startsWith('https://') && imageUrl != initialImageUrl) {
-          onReplace({ url: imageUrl, alt: imageAlt });
+        onReplace({ url: imageUrl, alt: imageAlt });
+        finish();
+        return;
       }
       if (imageUploadOption == 'upload' && imageFile) {
         onReplace({ url: '', alt: imageAlt, img: imageFile as File });
+        // Simulate async upload: finish() will be called after animation
       }
     }
 
-    setTimeout(() => {
-      setUploadProgress(66);
-    }, 0.3 * 1000);
+    const steps = [
+      33 + Math.floor(Math.random() * 12), // 33-45
+      49 + Math.floor(Math.random() * 18), // 49-69
+      69 + Math.floor(Math.random() * 20), // 69-89
+      98
+    ];
 
-
-    setTimeout(() => {
-      setUploadProgress(88);
-    }, 0.7 * 1000);
-
-    setTimeout(() => {
-      setIsUploading(false);
-      setUploadProgress(98);
-    }, 0.9 * 1000);
+    let i = 0;
+    function nextStep() {
+      if (i < steps.length) {
+        setTimeout(() => {
+          setUploadProgress(steps[i]);
+          i++;
+          nextStep();
+        }, 200 + Math.random() * 500); // 200-700ms between steps
+      } else {
+        // If upload not done, show finishing spinner at 98%
+        setFinishing(true);
+        // Poll every 400ms for up to 10s (simulate async upload completion)
+        let waited = 0;
+        const poll = () => {
+          if (uploadDone || waited > 10000) {
+            finish();
+          } else {
+            setTimeout(() => {
+              waited += 400;
+              poll();
+            }, 400);
+          }
+        };
+        poll();
+      }
+    }
+    nextStep();
   };
 
   return (
     <Modal
       opened={imageModalOpen}
       onClose={handleCloseModal}
-      title={<>{mode === 'replace' ? 'Replace Image' : 'Image Preview'} <Button
-          variant={mode == 'replace' ? 'subtle' : 'light'}
-          color={mode == 'replace' ? 'gray' : 'fuchsia'}
-          leftSection={mode == 'replace' ? <IconPhotoPlus size={16} /> : <IconUpload size={16} />}
-          onClick={onToggleMode}
-          className={`font-bold border-2 ml-12 ${mode == 'replace' ? 'border-gray-300 text-gray-700 hover:bg-gray-100' : 'border-fuchsia-300 text-fuchsia-700 hover:bg-fuchsia-100'} `}
-        >
-          {mode == 'preview' ? 'Replace Image' : 'Preview'}
-        </Button></>}
-      size="96%"
+      title={
+        <>
+          {mode === 'replace' ? 'Replace Image' : 'Preview Image'}
+          {!disableReplace && <Button
+            variant={mode == 'replace' ? 'subtle' : 'light'}
+            color={mode == 'replace' ? 'gray' : 'fuchsia'}
+            leftSection={mode == 'replace' ? <IconPhotoPlus size={16} /> : <IconUpload size={16} />}
+            onClick={onToggleMode}
+            className={`font-bold border-2 ml-12 ${mode == 'replace' ? 'border-gray-300 text-gray-700 hover:bg-gray-100' : 'border-fuchsia-300 text-fuchsia-700 hover:bg-fuchsia-100'} `}
+            size={isMobile ? 'xs' : 'sm'}
+          >
+            {mode == 'preview' ? 'Replace Image' : 'Preview'}
+          </Button>}
+        </>
+      }
+      size={isMobile ? '100%' : '96%'}
       centered
       radius="xl"
-      classNames={{ content: 'border-4 border-fuchsia-200 bg-gradient-to-br from-fuchsia-50 to-sky-50 shadow-xl' }}
+      classNames={{ content: 'pb-[0px] border-4 border-fuchsia-200 bg-gradient-to-br from-fuchsia-50 to-sky-50 shadow-xl p-0' }}
+      styles={{
+        content: {
+          padding: isMobile ? 0 : undefined,
+          minHeight: isMobile ? '100dvh' : undefined,
+          maxHeight: isMobile ? '100dvh' : undefined,
+          display: 'flex',
+          flexDirection: 'column',
+        },
+      }}
     >
-      <Stack my="md" gap="md">
-        {mode == 'preview' && (
-          <Paper withBorder p="xs" radius="md">
-            {/* {Future: Edit Canvas/Gen AI /Clipper Controls, enable a toolbar in preview mode' - insert text )} */}
-            <Center style={{ background: 'var(--mantine-color-gray-0)' }} p="xs">
-              {isUploading ? (
-                <Loader size="sm" />
-              ) : (
-                <img
-                  src={previewUrl || imageUrl || PLACEHOLDER}
-                  alt={imageAlt || 'Preview'}
+      <Stack my={isMobile ? 0 : 'md'} gap={isMobile ? 4 : 'md'} style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        <div style={{ flex: 1, overflowY: 'auto', padding: isMobile ? '8px 8px 72px 8px' : '20px 24px 90px 24px' }}>
+          {mode == 'preview' && (
+            <Paper withBorder p="xs" radius="md">
+              {/* {Future: Edit Canvas/Gen AI /Clipper Controls, enable a toolbar in preview mode' - insert text )} */}
+              <Center style={{ background: 'var(--mantine-color-gray-0)' }} p="xs">
+                {isUploading ? (
+                  <Loader size="sm" />
+                ) : (
+                  <img
+                    src={previewUrl || imageUrl || PLACEHOLDER}
+                    alt={imageAlt || 'Preview'}
                     style={{
                     objectFit: 'contain',
                     border: maxWidth ? '2px dashed #e879f9' : 'none',
@@ -161,96 +319,136 @@ const ImageModal = ({
                     (e.target as HTMLImageElement).src = PLACEHOLDER;
                   }}
                 />
+                )}
+              </Center>
+              {maxWidth && (
+                <Text size="xs" c="dimmed" ta="center">Crop width: <strong>{maxWidth}</strong>px</Text>
               )}
-            </Center>
-            {maxWidth && (
-              <Text size="xs" c="dimmed" ta="center">Crop width: <strong>{maxWidth}</strong>px</Text>
-            )}
-          </Paper>
-        )}
-        {mode === 'replace' && (
-          <>
-            <SegmentedControl
-              value={imageUploadOption}
-              onChange={value => setImageUploadOption(value as 'url' | 'upload')}
-              data={[
-                { label: 'Image URL', value: 'url' },
-                { label: 'Upload Image', value: 'upload' },
-              ]}
-              fullWidth
-            />
-            {imageUploadOption === 'url' && (
-              <TextInput
-                label="Image URL"
-                readOnly
-                placeholder="https://example.com/image.jpg"
-                value={imageUrl}
-                onChange={e => setImageUrl(e.currentTarget.value)}
-                required
-                leftSection={<IconLink size={16} />}
-                data-autofocus
+            </Paper>
+          )}
+          {mode === 'replace' && (
+            <>
+              <SegmentedControl
+                value={imageUploadOption}
+                onChange={value => setImageUploadOption(value as 'url' | 'upload')}
+                data={[
+                  { label: 'Image URL', value: 'url' },
+                  { label: 'Upload Image', value: 'upload' },
+                ]}
+                fullWidth
               />
-            )}
-            {imageUploadOption === 'upload' && (
-              <Stack my="xs">
-                <Text size="sm" fw={500}>Upload Image</Text>
-                <Paper withBorder p="md" radius="md" bg={previewUrl ? 'transparent' : 'var(--mantine-color-gray-0)'}>
-                  {!previewUrl ? (
-                    <Dropzone
-                      onDrop={(files) => handleFileUpload(files[0])}
-                      onReject={() => { }}
-                      maxSize={5 * 1024 * 1024}
-                      accept={["image/png", "image/jpeg", "image/gif"]}
-                      multiple={false}
+              {imageUploadOption === 'url' && (
+                <>
+                  <TextInput
+                    label="Image URL or search keywords"
+                    placeholder="Paste an image URL or type something like 'cat' or 'mountain'"
+                    value={imageUrl}
+                    onChange={e => setImageUrl(e.currentTarget.value)}
+                    required
+                    leftSection={<IconLink size={16} />}
+                    data-autofocus
+                    style={{ flex: 1 }}
+                    error={urlError}
+                  />
+                  <Group gap={4} align="center" justify="flex-start" style={{ marginTop: 8, flexDirection: isMobile ? 'column' : 'row', width: '100%' }}>
+                    <Button
+                      variant="light"
+                      color="blue"
+                      size={isMobile ? 'xs' : 'sm'}
+                      radius={isMobile ? 'md' : 'xl'}
+                      leftSection={<IconDownload size={16} />}
+                      onClick={async () => {
+                        setUrlError(null);
+                        if (!imageUrl) return;
+                        // Always use proxy for user-supplied URLs
+                        const proxyUrl = `/api/markket/img?action=proxy&url=${encodeURIComponent(imageUrl)}`;
+                        await handleLoadFromUrlProxy(proxyUrl);
+                      }}
+                      style={{ fontWeight: 600, width: isMobile ? '100%' : undefined }}
                     >
-                      <Stack my="md" align="center" py={20}>
-                        <IconFileUpload size={32} opacity={0.5} />
-                        <div>
-                          <Text size="sm">Drag images here or click to select files</Text>
-                          <Text size="xs" c="dimmed">JPEG, PNG, GIF up to 5MB</Text>
-                        </div>
-                        <FileButton
-                          onChange={handleFileUpload}
-                          accept="image/png,image/jpeg,image/gif"
-                        >
-                          {(props) => (
-                            <Button
-                              variant="light"
-                              radius="md"
-                              leftSection={<IconUpload size={14} />}
-                              {...props}
-                            >
-                              Select file
-                            </Button>
-                          )}
-                        </FileButton>
-                      </Stack>
-                    </Dropzone>
-                  ) : (
-                    <Stack my="md">
+                      Load from URL
+                    </Button>
+                    <Button
+                      variant="light"
+                      color="pink"
+                      size={isMobile ? 'xs' : 'sm'}
+                      radius={isMobile ? 'md' : 'xl'}
+                      leftSection={<IconSparkles size={16} />}
+                      loading={unsplashLoading}
+                      onClick={handleRandomUnsplash}
+                      style={{ fontWeight: 600, width: isMobile ? '100%' : undefined }}
+                    >
+                      Unsplash
+                    </Button>
+                  </Group>
+                </>
+              )}
+              {imageUploadOption === 'upload' && (
+                <Stack my="xs">
+                  <Text size="sm" fw={500}>Upload Image</Text>
+                  <Paper withBorder p="md" radius="md" bg={previewUrl ? 'transparent' : 'var(--mantine-color-gray-0)'}>
+                    {!previewUrl ? (
+                      <Dropzone
+                        onDrop={(files) => handleFileUpload(files[0])}
+                        onReject={() => { }}
+                        maxSize={5 * 1024 * 1024}
+                        accept={["image/png", "image/jpeg", "image/gif", "image/webp", "image/avif"]}
+                        multiple={false}
+                      >
+                        <Stack my="md" align="center" py={20}>
+                          <IconFileUpload size={32} opacity={0.5} />
+                          <div>
+                            <Text size="sm">Drag images here or click to select files</Text>
+                            <Text size="xs" c="dimmed">JPEG, PNG, GIF up to 5MB</Text>
+                          </div>
+                          <FileButton
+                            onChange={handleFileUpload}
+                            accept="image/png,image/jpeg,image/gif"
+                          >
+                            {(props) => (
+                              <Button
+                                variant="light"
+                                radius="md"
+                                leftSection={<IconUpload size={14} />}
+                                {...props}
+                              >
+                                Select file
+                              </Button>
+                            )}
+                          </FileButton>
+                        </Stack>
+                      </Dropzone>
+                    ) : (
+                      <Stack my="md">
                         <Box pos="relative" className='max-h-[200px] overflow-scroll max-w-[96%] mx-auto'>
-                        <MantineImage
-                          src={previewUrl}
-                          alt="Preview"
+                            <MantineImage
+                              src={previewUrl}
+                              alt="Preview"
                             height={'200px'}
-                          fit="contain"
-                          radius="md"
-                        />
-                        <ActionIcon
-                          color="red"
-                          variant="filled"
-                          radius="xl"
-                          size="sm"
-                          style={{ position: 'absolute', top: 5, right: 5 }}
-                          onClick={resetFileInput}
-                        >
-                          <IconX size={14} />
-                        </ActionIcon>
-                      </Box>
+                              fit="contain"
+                              radius="md"
+                            />
+                            <ActionIcon
+                              color="red"
+                              variant="filled"
+                              radius="xl"
+                              size="sm"
+                              style={{ position: 'absolute', top: 5, right: 5 }}
+                              onClick={resetFileInput}
+                            >
+                              <IconX size={14} />
+                            </ActionIcon>
+                          </Box>
                         {uploadProgress > 0 && (
                           <Stack mt="md">
                             <Group justify="apart" m="md">
-                              <Text size="xs">Uploading...</Text>
+                                <Text size="xs">
+                                  {finishing ? (
+                                    <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                                      <Loader size="xs" color="pink" /> Finishing up...
+                                    </span>
+                                  ) : 'Uploading...'}
+                                </Text>
                               <Text size="xs" fw={500}>{uploadProgress}%</Text>
                             </Group>
                             <Progress
@@ -264,34 +462,66 @@ const ImageModal = ({
                         <Text size="sm" truncate fw={500}>
                           {imageFile?.name}
                         </Text>
-                    </Stack>
-                  )}
-                </Paper>
-              </Stack>
-            )}
-          </>
-        )}
-        <TextInput
-          label="Alt Text"
-          placeholder="Descriptive text for the image"
-          value={imageAlt}
-          onChange={e => setImageAlt(e.currentTarget.value)}
-          description="Add accessible description of the image content"
-        />
-        <Group align="right" mt="md">
-          <Button variant="subtle" onClick={handleCloseModal}>
-            Dismiss
-          </Button>
-          {mode == 'replace' && (
-            <Button
-              onClick={handleReplaceImage}
-              disabled={(uploadProgress > 0 && uploadProgress < 100) || !(imageUrl || previewUrl) || (imageUploadOption == 'upload' && !imageFile)}
-              leftSection={<IconPhotoPlus size={16} />}
-            >
-              { imageUploadOption == 'upload' ?  'Upload' : 'Replace'}
-            </Button>
+                      </Stack>
+                    )}
+                  </Paper>
+                </Stack>
+              )}
+            </>
           )}
-        </Group>
+          <TextInput
+            label="Alt Text"
+            placeholder="Descriptive text for the image"
+            value={imageAlt}
+            onChange={e => setImageAlt(e.currentTarget.value)}
+            description="Add accessible description of the image content"
+          />
+        </div>
+        <div
+          style={{
+            position: 'sticky',
+            bottom: 0,
+            left: 0,
+            width: '100%',
+            background: 'linear-gradient(to top, #fdf4ff 90%, transparent)',
+            zIndex: 10,
+            padding: isMobile ? '10px 8px' : '18px 32px',
+            borderTop: '2px solid #f0abfc',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: 12,
+            boxShadow: '0 -2px 16px 0 rgba(236, 72, 153, 0.07)',
+          }}
+        >
+          <Text size={isMobile ? 'xs' : 'sm'} c="dimmed" fw={500}>
+            {mode === 'replace' ? 'Ready to update your image?' : 'Preview your image'}
+          </Text>
+          <Group gap={isMobile ? 6 : 12}>
+            <Button
+              variant="outline"
+              color="gray"
+              onClick={handleCloseModal}
+              size={isMobile ? 'sm' : 'md'}
+              radius={isMobile ? 'md' : 'xl'}
+              style={{ fontWeight: 600 }}
+            >
+              Cancel
+            </Button>
+            {mode == 'replace' && (
+              <Button
+                onClick={handleReplaceImage}
+                disabled={disableReplace || (uploadProgress > 0 && uploadProgress < 100) || !(imageUrl || previewUrl) || (imageUploadOption == 'upload' && !imageFile)}
+                leftSection={<IconPhotoPlus size={18} />}
+                size={isMobile ? 'sm' : 'md'}
+                radius={isMobile ? 'md' : 'xl'}
+                style={{ fontWeight: 700, background: 'linear-gradient(90deg, #f472b6 0%, #818cf8 100%)', color: '#fff', boxShadow: '0 2px 8px 0 #fbbf24a0' }}
+              >
+                {imageUploadOption == 'upload' ? 'Upload & Save' : 'Replace & Save'}
+              </Button>
+            )}
+          </Group>
+        </div>
       </Stack>
     </Modal>
   );

--- a/app/components/dashboard/item.image.manager.tsx
+++ b/app/components/dashboard/item.image.manager.tsx
@@ -1,5 +1,5 @@
 import { ContentTypes, Store } from "@/markket"
-import { Group, Tooltip, ScrollArea, Paper, Text, Title, Button, Stack, Box, Modal } from '@mantine/core';
+import { Group, Tooltip, Paper, Text, Title, Button, Stack, Box, Modal } from '@mantine/core';
 import { useState } from 'react';
 import ImageModal from './image.modal';
 import { IconCactus, IconCameraPlus, IconTrash } from "@tabler/icons-react";
@@ -7,6 +7,7 @@ import { IconCactus, IconCameraPlus, IconTrash } from "@tabler/icons-react";
 import { ImageConfig, ImageActions } from './item.image.config';
 
 import { updateContentAction, } from '@/markket/action.helpers';
+import { markketConfig } from "@/markket/config";
 
 export type ImageManagerProps = {
   item?: ContentTypes,
@@ -15,7 +16,7 @@ export type ImageManagerProps = {
   refresh?: () => null;
 }
 
-const PLACEHOLDER = 'https://markketplace.nyc3.digitaloceanspaces.com/uploads/4dd22c1b57887fe28307fb4784c974bb.png';
+const PLACEHOLDER = markketConfig.blank_image_url;
 
 const map = ImageConfig;
 const actions = ImageActions;
@@ -37,6 +38,7 @@ const ImageManager = ({ store, singular, item, refresh }: ImageManagerProps) => 
     maxWidth?: number;
     mode?: 'preview' | 'replace';
     multiIndex?: number;
+    disableReplace?: boolean;
   }>({ open: false });
   const [confirmState, setConfirmState] = useState<{ open: boolean, key?: string, imgId?: string | number, index?: number }>({ open: false });
 
@@ -99,80 +101,79 @@ const ImageManager = ({ store, singular, item, refresh }: ImageManagerProps) => 
             );
           })}
         </Group>
-        {/* Multi-image types */}
         {multiKeys.map((key) => {
           const imgs = Array.isArray(getNested(item, key)) ? getNested(item, key) : [];
 
           return (
-            <Box key={key} style={{ width: '100%' }}>
+            <Box key={key}>
               <Text className="font-extrabold text-blue-700 mb-1 tracking-wide rounded-lg px-2 py-1">
                 {key}
               </Text>
-              <ScrollArea type="auto" offsetScrollbars>
-                <Group gap="md" align="center" wrap="nowrap">
-                  {(imgs.length > 0 ? [...imgs, {}] : [{}]).map((img: any, i: number) => {
-                    if (i >= 5) { return <span key={key + i} /> }
+              <Group gap="md" align="center" wrap="wrap" style={{ width: '100%', flexWrap: 'wrap' }}>
+                {(imgs.length > 0 ? [...imgs, {}] : [{}]).map((img: any, i: number) => {
+                  if (i >= 5) { return <span key={key + i} /> }
 
-                    const src = img && img.url ? img.url : PLACEHOLDER;
-                    const alt = img && img.alternativeText ? img.alternativeText : `${key} #${i + 1}`;
-                    return (
-                      <Box key={key + i} style={{ textAlign: 'center' }}>
-                        <Group>
-                          {img?.url ? (
-                            <Button
-                              size="xs"
-                              variant="subtle"
-                              color="red"
-                              className="mt-1 border-2 border-red-300 font-bold text-red-700 hover:bg-red-100"
-                              onClick={() => setConfirmState({ open: true, key, imgId: img.id, index: i })}
-                              title="Remove image"
-                            >
-                              <IconTrash size={18} />
-                            </Button>
-                          ) : (
-                            <Button
-                              size="xs"
-                              variant="light"
-                              color="blue"
-                              className={`mt-1 border-2 border-blue-300 font-bold text-blue-700 hover:bg-blue-100 `}
-                              onClick={() => setModalState({ open: true, key, url: src, alt, maxWidth: config[key]?.max_width, mode: (img?.url ? 'preview' : 'replace'), multiIndex: i })}
-                            >
-                              <IconCameraPlus size={18} color={`#db2777`} />
-                            </Button>
-                          )}
-                          <Text className="text-left font-extrabold text-blue-700 mt-1 text-xs tracking-wide rounded-lg px-2 py-1 inline-block">
-                            #{i + 1}
-                          </Text>
-                        </Group>
-                        <Tooltip label={`${key} #${i + 1}`}>
-                          <img
-                            src={src}
-                            alt={alt}
-                            style={{
-                              height: THUMB_SIZE,
-                              width: THUMB_SIZE,
-                              objectFit: 'cover',
-                              borderRadius: 16,
-                              border: '4px solid #38bdf8',
-                              boxShadow: '3px 3px 0 #000',
-                              background: '#fff',
-                              marginRight: 12,
-                              cursor: config[key].can_change == false ? 'not-allowed' : 'pointer',
-                              transition: 'transform 0.1s',
-                            }}
-                            onClick={() => (config[key].can_change != false) && setModalState({ open: true, key, url: src, alt, maxWidth: config[key]?.max_width, mode: (img?.url ? 'preview' : 'replace'), multiIndex: i })}
-                          />
-                        </Tooltip>
-                      </Box>
-                    );
-                  })}
-                </Group>
-              </ScrollArea>
+                  const src = img && img.url ? img.url : PLACEHOLDER;
+                  const alt = img && img.alternativeText ? img.alternativeText : `${key} #${i + 1}`;
+
+                  return (
+                    <Box key={key + i} style={{ textAlign: 'center', minWidth: THUMB_SIZE + 8, maxWidth: 140, boxSizing: 'border-box', overflow: 'hidden', marginBottom: 8 }}>
+                      <Group>
+                        {img?.url ? (
+                          <Button
+                            size="xs"
+                            variant="subtle"
+                            color="red"
+                            className="mt-1 border-2 border-red-300 font-bold text-red-700 hover:bg-red-100"
+                            onClick={() => setConfirmState({ open: true, key, imgId: img.id, index: i })}
+                            title="Remove image"
+                          >
+                            <IconTrash size={18} />
+                          </Button>
+                        ) : (
+                          <Button
+                            size="xs"
+                            variant="light"
+                            color="blue"
+                            className={`mt-1 border-2 border-blue-300 font-bold text-blue-700 hover:bg-blue-100 `}
+                            onClick={() => setModalState({ open: true, key, url: src, alt, maxWidth: config[key]?.max_width, mode: (img?.url ? 'preview' : 'replace'), multiIndex: i })}
+                          >
+                            <IconCameraPlus size={18} color={`#db2777`} />
+                          </Button>
+                        )}
+                        <Text className="text-left font-extrabold text-blue-700 mt-1 text-xs tracking-wide rounded-lg px-2 py-1 inline-block">
+                          #{i + 1}
+                        </Text>
+                      </Group>
+                      <Tooltip label={`${key} #${i + 1}`}>
+                        <img
+                          src={src}
+                          alt={alt}
+                          style={{
+                            height: THUMB_SIZE,
+                            width: THUMB_SIZE * 1.1,
+                            objectFit: 'cover',
+                            borderRadius: 16,
+                            border: '4px solid #38bdf8',
+                            boxShadow: '3px 3px 0 #000',
+                            background: '#fff',
+                            marginRight: 8,
+                            cursor: config[key].can_change == false ? 'not-allowed' : 'pointer',
+                            transition: 'transform 0.1s',
+                            maxWidth: 120,
+                          }}
+                          onClick={() => (config[key].can_change != false) && setModalState({ disableReplace: img.url, open: true, key, url: src, alt, maxWidth: config[key]?.max_width, mode: (img?.url ? 'preview' : 'replace'), multiIndex: i })}
+                        />
+                      </Tooltip>
+                    </Box>
+                  );
+                })}
+              </Group>
             </Box>
           );
         })}
       </Stack>
-      {/* Confirm Modal for deleting multi-image */}
+
       <Modal opened={confirmState.open} onClose={() => setConfirmState({ open: false })} title="Remove Image?" centered>
         <Text mb="md">Are you sure you want to remove this image? This cannot be undone.</Text>
         <Group justify="flex-end">
@@ -191,6 +192,7 @@ const ImageManager = ({ store, singular, item, refresh }: ImageManagerProps) => 
           }}>Remove</Button>
         </Group>
       </Modal>
+
       <ImageModal
         imageModalOpen={modalState.open}
         handleCloseModal={() => setModalState({ open: false })}
@@ -198,11 +200,11 @@ const ImageManager = ({ store, singular, item, refresh }: ImageManagerProps) => 
         imageAlt={modalState.alt}
         maxWidth={modalState.maxWidth}
         mode={modalState.mode}
+        disableReplace={modalState.disableReplace}
         onReplace={async ({ url, img, alt }: { url?: string, img?: File, alt?: string }) => {
           if (!modalState.key) return setModalState({ open: false });
-
           if (url) {
-            // @TODO: PUT request to replace image in the singular record
+            // Image Modal loads URL into Canvas and uploads as file
           } else {
             await actions[singular](item).upload(modalState.key, img, alt || modalState.key, modalState.multiIndex);
             if (refresh) refresh();
@@ -210,7 +212,7 @@ const ImageManager = ({ store, singular, item, refresh }: ImageManagerProps) => 
 
           setTimeout(() => {
             setModalState({ open: false });
-          }, 100);
+          }, 300);
         }}
         onInsert={() => setModalState({ open: false })}
         onToggleMode={() => setModalState((s) => ({ ...s, mode: s.mode === 'preview' ? 'replace' : 'preview' }))}

--- a/markket/config.ts
+++ b/markket/config.ts
@@ -13,7 +13,7 @@ export const markketConfig = {
   max_albums_per_store: 15,
   max_tracks_per_album: 25,
   max_events_per_store: 25,
-  blank_image_url: "https://markketplace.nyc3.digitaloceanspaces.com/uploads/8c99b7f0412e6ececd4fae78e3617ae7.png",
+  blank_image_url: "https://markketplace.nyc3.digitaloceanspaces.com/uploads/4dd22c1b57887fe28307fb4784c974bb.png",
   blank_favicon_url: "https://markketplace.nyc3.digitaloceanspaces.com/uploads/43c188106f4d950987346842a05e0cbf.png",
   blank_logo_url: "https://markketplace.nyc3.digitaloceanspaces.com/uploads/f96148440e7ccf81fe2c36a779c06e30.png",
   blank_cover_url: "https://markketplace.nyc3.digitaloceanspaces.com/uploads/c2491ef7c413165be47c9882a08d7ffd.png",
@@ -29,4 +29,7 @@ export const markketConfig = {
   markket_api_key: process.env.MARKKET_API_KEY || '',
   /** CISION_CREDENTIALS */
   cision: process.env.CISION_CREDENTIALS || '',
+  extensions: {
+    unsplash_access_key: process.env.NEXT_PUBLIC_UNSPLASH_ACCESS_KEY || '',
+  }
 };


### PR DESCRIPTION
**✨ Neobrutalist Image Modal & Manager Improvements**

Features & Improvements
Image Modal:

Added playful, randomized progress bar with “Finishing up…” state for robust UX on slow uploads.
“Replace” button is now disabled for multi-image fields (prevents confusion, only allows upload for new images).
Accepts new disableReplace prop for flexible control.
Improved Unsplash integration: “Random Unsplash” button uses input as a search query if present, or fetches a random image if not.
UI/UX polish for mobile and accessibility.
Image Manager:

Passes disableReplace to modal for multi-image fields.
General code cleanup and improved feedback for image actions.
Backend:

Unsplash endpoint now supports query param for keyword-based random images.
Why
Makes the dashboard more robust, playful, and user-friendly.
Prevents accidental “replace” actions on multi-image fields.
Handles slow uploads gracefully.
Enables creative image search and selection for users.